### PR TITLE
Bump ulanzi-plugin-starter to 1.2.3

### DIFF
--- a/plugin-starter/package.json
+++ b/plugin-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ulanzi-plugin-starter",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Scaffolding for Ulanzi Deck & Dial Plugins",
   "bin": {
     "ulanzi-plugin": "bin/cli.mjs"


### PR DESCRIPTION
## Summary
- Bump version so the restart-target fix from #9 (graceful AppleScript quit + pgrep polling instead of immediate killall) ships to npm.

## Test plan
- [ ] After merge, run `npm publish` from `plugin-starter/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)