### PR TITLE
chore: bump GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/deploy-marketing-site.yml
+++ b/.github/workflows/deploy-marketing-site.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Deploy to FTP
-        uses: SamKirkland/FTP-Deploy-Action@v4.3.5
+        uses: SamKirkland/FTP-Deploy-Action@v4.4.0
         with:
           server: ${{ secrets.FTP_HOST }}
           username: ${{ secrets.FTP_USER }}

--- a/.github/workflows/publish-catalog.yml
+++ b/.github/workflows/publish-catalog.yml
@@ -82,7 +82,7 @@ jobs:
         # Dry-runs on PRs must not touch the rolling issue (and the PR token from a
         # fork would be read-only anyway).
         if: always() && github.event_name != 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/release-app.yml
+++ b/.github/workflows/release-app.yml
@@ -89,12 +89,12 @@ jobs:
           git tag "v${{ needs.version.outputs.version }}"
           git push origin "v${{ needs.version.outputs.version }}"
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: release-assets
           merge-multiple: true
 
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ needs.version.outputs.tag }}
           name: ${{ needs.version.outputs.tag }}

--- a/.github/workflows/validate-registry-pr.yml
+++ b/.github/workflows/validate-registry-pr.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Comentar resultado no PR
         if: always()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         env:
           MD_PATH: ${{ runner.temp }}/pr-validation.md
         with:


### PR DESCRIPTION
## O que muda

Atualiza as GitHub Actions defasadas em todos os workflows para a última major. As majors antigas de `download-artifact` e `action-gh-release` ainda embarcavam **Node 20** (deprecado em favor do Node 24), gerando warnings em vários jobs.

| Action | Antes | Depois | Workflow |
|---|---|---|---|
| actions/github-script | v7 | v9 | validate-registry-pr, publish-catalog |
| actions/download-artifact | v4 | v8 | release-app |
| softprops/action-gh-release | v2 | v3 | release-app |
| SamKirkland/FTP-Deploy-Action | v4.3.5 | v4.4.0 | deploy-marketing-site |

As demais já estavam na última versão e não foram tocadas: `checkout@v7`, `setup-node@v7`, `upload-artifact@v7`, `upload-pages-artifact@v5`, `deploy-pages@v5`, `setup-trivy@v0.3.1`.

## Atenção

`download-artifact` foi para v8 enquanto `upload-artifact` no mesmo workflow segue em v7 — os formatos são compatíveis entre essas versões, mas vale conferir o primeiro run do `release-app`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)