### PR TITLE
Mention the plugin maintainer when findings are reported

### DIFF
--- a/packages/catalog/bin/build-catalog.mjs
+++ b/packages/catalog/bin/build-catalog.mjs
@@ -41,6 +41,12 @@ function anchorFor(repo) {
   return repo.replace(/[^a-z0-9]+/gi, '-').toLowerCase().replace(/^-+|-+$/g, '');
 }
 
+// `owner/name` → `owner`. Real GitHub handle (unlike manifest.json's free-text Author),
+// used to credit/link the maintainer on the security report.
+function ownerOf(repo) {
+  return repo.split('/')[0];
+}
+
 function reportUrlFor(repo) {
   return PAGES_BASE_URL ? `${PAGES_BASE_URL}/security.html#${anchorFor(repo)}` : null;
 }
@@ -278,6 +284,7 @@ function buildSecurityHtml(plugins, generatedAt) {
       const scanned = s.scannedAt ? escapeHtml(s.scannedAt.slice(0, 10)) : '—';
       const ref = s.scannedRef ? `<code>${escapeHtml(s.scannedRef)}</code>` : '—';
       const sv = s.scanner ? `${escapeHtml(s.scanner.name)} ${escapeHtml(s.scanner.version)}` : '—';
+      const owner = ownerOf(p.repo);
       return `      <tr id="${escapeHtml(anchorFor(p.repo))}" class="s-${escapeHtml(s.status)}">
         <td><a href="${escapeHtml(p.sourceUrl)}">${escapeHtml(p.name)}</a><div class="repo">${escapeHtml(p.repo)}</div></td>
         <td class="status">${STATUS_LABEL[s.status] || escapeHtml(s.status)}</td>
@@ -285,6 +292,7 @@ function buildSecurityHtml(plugins, generatedAt) {
         <td class="num">${s.high || 0}</td>
         <td class="num">${s.secrets || 0}</td>
         <td>${scanned}<div class="repo">${ref} · ${sv}</div></td>
+        <td><a href="https://github.com/${escapeHtml(owner)}">@${escapeHtml(owner)}</a></td>
       </tr>`;
     })
     .join('\n');
@@ -323,7 +331,7 @@ function buildSecurityHtml(plugins, generatedAt) {
   <div class="meta">Scanned with ${scannerLabel} · ${escapeHtml(generatedAt)}${summary ? ` · ${summary}` : ''}</div>
   <table>
     <thead>
-      <tr><th>Plugin</th><th>Status</th><th class="num">Critical</th><th class="num">High</th><th class="num">Secrets</th><th>Scanned</th></tr>
+      <tr><th>Plugin</th><th>Status</th><th class="num">Critical</th><th class="num">High</th><th class="num">Secrets</th><th>Scanned</th><th>Maintainer</th></tr>
     </thead>
     <tbody>
 ${body}

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -132,6 +132,12 @@ function sevRank(s) {
   return { CRITICAL: 0, HIGH: 1, MEDIUM: 2, LOW: 3, UNKNOWN: 4 }[s] ?? 5;
 }
 
+// The repo owner (`owner/name` → `owner`) is a real GitHub handle, unlike the free-text
+// `Author` in manifest.json — safe to @-mention inside our own issue/comments.
+function mentionFor(repo) {
+  return `@${repo.split('/')[0]}`;
+}
+
 // Compact, machine-readable record consumed by build-catalog.mjs. One file per
 // registry entry, so the join key is the registry filename.
 //   status: clean | findings | error   (build-catalog fills `unknown` when absent)
@@ -176,8 +182,19 @@ function buildReport(results) {
   }
   lines.push('');
 
+  if (withFindings.length) {
+    // Deduped so an author with several plugins is only pinged once. This is our own
+    // issue/comment, so the mention is a real GitHub notification — not a message
+    // posted on a third-party repo.
+    const mentions = [...new Set(withFindings.map((r) => mentionFor(r.repo)))];
+    lines.push(`**Maintainers to ping:** ${mentions.join(' ')}`);
+    lines.push('');
+  }
+
   for (const r of withFindings) {
     lines.push(`## ❌ ${r.repo}`);
+    lines.push('');
+    lines.push(`Maintainer: ${mentionFor(r.repo)}`);
     lines.push('');
     if (r.vulns.length) {
       const rows = [...r.vulns].sort((a, b) => sevRank(a.severity) - sevRank(b.severity)).slice(0, MAX_ROWS);


### PR DESCRIPTION
## Summary

Follow-up to #11. Instead of opening issues on third-party repos (permission we don't have, and unsolicited bot issues on someone else's repo would be a bad look while we're actively onboarding contributors), this credits/pings the maintainer using data we already trust: the repo owner (`owner/name` → `owner`), which is a real GitHub handle — unlike `manifest.json`'s free-text `Author` field.

- **Our own rolling issue** (`security-scan.mjs`): the report now has a top "Maintainers to ping: @a @b" line (deduped) plus a per-repo "Maintainer: @owner" line — only for repos with actual findings (vulns/secrets), not scan errors, which are usually our side's fault (rate limits, clone failures) rather than the author's. Since this lives in *our* issue, `@owner` is a real GitHub notification — nothing gets posted to the plugin's own repo.
- **The public report** (`security.html` on Pages, `build-catalog.mjs`): added a Maintainer column linking to the owner's GitHub profile, for every row — a visual credit, not a notification.

## Test plan

- [x] `node --check` on both scripts
- [x] Simulated `buildReport()` mention output against a findings + a clean repo — dedup and per-repo line format correct
- [x] Rebuilt the real catalog with a mocked findings record and rendered `security.html` in a browser — Maintainer column shows `@owner` linked to the profile, layout unaffected
- [ ] Next real scan run: confirm the rolling issue body shows the "Maintainers to ping" line when there are findings (currently `beyondlevi/gcp-monitor-ulanzi-plugin` has 1 HIGH)

🤖 Generated with [Claude Code](https://claude.com/claude-code)