### PR TITLE
Always install latest Trivy

### DIFF
--- a/.github/workflows/publish-catalog.yml
+++ b/.github/workflows/publish-catalog.yml
@@ -57,8 +57,6 @@ jobs:
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@v0.3.1
         with:
-          version: v0.72.0
-          cache: true
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run security scan


### PR DESCRIPTION
## Summary
- Removes the pinned `version: v0.72.0` from the `aquasecurity/setup-trivy` step so the daily security scan always runs against the latest Trivy release.
- Drops `cache: true`, since setup-trivy doesn't support caching when the version is empty/latest.

## Test plan
- [ ] Confirm the `publish-catalog` workflow run installs a current Trivy version and the security scan step still succeeds.