### PR TITLE
Cache-bust og:image URLs with a content hash

### DIFF
--- a/packages/catalog/bin/build-catalog.mjs
+++ b/packages/catalog/bin/build-catalog.mjs
@@ -8,6 +8,7 @@
 // In the Action, GITHUB_TOKEN is injected automatically.
 
 import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { Resvg } from '@resvg/resvg-js';
@@ -198,7 +199,12 @@ async function generateBanner(entry) {
     });
     await mkdir(OG_DIR, { recursive: true });
     await writeFile(join(OG_DIR, `${ogSlug(entry.repo)}.png`), png);
-    return PAGES_BASE_URL ? `${PAGES_BASE_URL}/og/${ogSlug(entry.repo)}.png` : null;
+    // The filename is stable (overwritten each build), but aggressive scraper caches
+    // (Discord's image proxy) ignore cache-control and pin the URL. A content hash in the
+    // query string makes the og:image URL change iff the image changes, so a stale embed
+    // can never outlive a regenerated banner.
+    const bust = createHash('sha1').update(png).digest('hex').slice(0, 8);
+    return PAGES_BASE_URL ? `${PAGES_BASE_URL}/og/${ogSlug(entry.repo)}.png?v=${bust}` : null;
   } catch (err) {
     console.warn(`  ! banner render failed for ${entry.repo}: ${err.message}`);
     return null;


### PR DESCRIPTION
Follow-up to #23. The SVG-icon fix regenerated the banners correctly, but Discord kept showing the old preview: its image proxy pins the og:image by URL and ignores `cache-control`, and the banner path (`og/<slug>.png`) is stable across builds — so a regenerated image never busts the cached embed. (WhatsApp re-scraped and showed the new one.)

Append an 8-char sha1 of the PNG bytes as `?v=<hash>` to the og:image URL. The URL now changes iff the image bytes change, so scrapers re-fetch and a stale embed can't outlive a rebuild. The filename on disk stays the same; only the URL in the meta tag carries the hash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)