### PR TITLE
Add Codex Usage plugin (dahliasan/ulanzideck_codex)

### DIFF
--- a/registry/plugins/dahliasan__ulanzideck_codex.json
+++ b/registry/plugins/dahliasan__ulanzideck_codex.json
@@ -1,0 +1,1 @@
+{ "repo": "dahliasan/ulanzideck_codex" }


### PR DESCRIPTION
## Summary
- Registers [dahliasan/ulanzideck_codex](https://github.com/dahliasan/ulanzideck_codex) in the Community Store catalog.
- Ulanzi Deck plugin mirroring Claude Code Usage for ChatGPT Codex 5h + weekly limits.
- Public repo with release asset `com.codex.usage.ulanziPlugin.zip` on [v1.0.0](https://github.com/dahliasan/ulanzideck_codex/releases/tag/v1.0.0).

## Checklist
- [x] Public repo
- [x] `com.codex.usage.ulanziPlugin/manifest.json` at root
- [x] GitHub Release with `com.codex.usage.ulanziPlugin.zip`
- [x] Optional `store.json`


Made with [Cursor](https://cursor.com)