### PR TITLE
Add 3 plugins: window-switcher, apple-shortcuts, run-applescript

### DIFF
--- a/registry/plugins/narlei__ulanzideck-apple-shortcuts.json
+++ b/registry/plugins/narlei__ulanzideck-apple-shortcuts.json
@@ -1,0 +1,3 @@
+{
+  "repo": "narlei/ulanzideck-apple-shortcuts"
+}

--- a/registry/plugins/narlei__ulanzideck-run-applescript.json
+++ b/registry/plugins/narlei__ulanzideck-run-applescript.json
@@ -1,0 +1,3 @@
+{
+  "repo": "narlei/ulanzideck-run-applescript"
+}

--- a/registry/plugins/narlei__ulanzideck-window-switcher.json
+++ b/registry/plugins/narlei__ulanzideck-window-switcher.json
@@ -1,0 +1,3 @@
+{
+  "repo": "narlei/ulanzideck-window-switcher"
+}


### PR DESCRIPTION
## Summary
- Adds `narlei/ulanzideck-window-switcher` to the community registry
- Adds `narlei/ulanzideck-apple-shortcuts` to the community registry
- Adds `narlei/ulanzideck-run-applescript` to the community registry

Each repo has a `com.narlei.<plugin>.ulanziPlugin/` folder at its root and a `v1.0.0` GitHub Release with the plugin zip asset, per the [registry submission guide](registry/README.md).

## Test plan
- [x] `npm run catalog:validate` passes (20 plugin(s) valid)
- [ ] GitHub Action reads `manifest.json` / `store.json` / latest release for each repo and publishes to the store on merge