### PR TITLE
Add beyondlevi plugins to the registry (Tuya Smart Control + ChatJump)

### DIFF
--- a/registry/plugins/beyondlevi__tuya-ulanzi-plugin.json
+++ b/registry/plugins/beyondlevi__tuya-ulanzi-plugin.json
@@ -1,0 +1,3 @@
+{
+  "repo": "beyondlevi/tuya-ulanzi-plugin"
+}

--- a/registry/plugins/beyondlevi__ulanzi-chatjump.json
+++ b/registry/plugins/beyondlevi__ulanzi-chatjump.json
@@ -1,0 +1,3 @@
+{
+  "repo": "beyondlevi/ulanzi-chatjump"
+}


### PR DESCRIPTION
Adds two of my plugins to the community registry, following the manual fork + PR process (per the maintainer's guidance that multiple plugins can go in a single PR).

### 1. Tuya Smart Control
- Repo: https://github.com/beyondlevi/tuya-ulanzi-plugin
- Latest release: `v1.1.6`, asset `com.ulanzi.tuya.ulanziPlugin_v1.1.6.zip`
- List and control Tuya / Smart Life devices from the Ulanzi keypad via the Tuya Cloud API (toggle, temperature +/-, send command), with live on/off + temperature status.

### 2. ChatJump
- Repo: https://github.com/beyondlevi/ulanzi-chatjump
- Latest release: `v1.2.2`, asset `com.ulanzi.chatjump.ulanziPlugin.zip`
- One-tap shortcuts to open favorite WhatsApp & Telegram chats straight in the desktop app, showing each contact's photo and name.

Both repos follow the expected layout (`com.<you>.<plugin>.ulanziPlugin/` subfolder with `manifest.json`, `store.json` + `resources/` at the root) and are public with a GitHub Release.

My other plugin (`beyondlevi/gcp-monitor-ulanzi-plugin`) is already in the registry, so it is not included here.

Context: opened as a follow-up to #34 (the web submission flow was failing with a 422).