### PR TITLE
Corrige /revalidate e escaneia segurança do repo submetido no PR

### DIFF
--- a/.github/workflows/validate-registry-pr.yml
+++ b/.github/workflows/validate-registry-pr.yml
@@ -58,10 +58,7 @@ jobs:
         id: pr
         env:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number || inputs.pr }}
-        run: |
-          echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
-          BASE=$(gh pr view "$PR_NUMBER" --json baseRefName --jq .baseRefName)
-          echo "base=$BASE" >> "$GITHUB_OUTPUT"
+        run: echo "number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
       - name: Checkout do PR
         if: github.event_name != 'pull_request'
@@ -70,10 +67,16 @@ jobs:
       - name: Detectar arquivos de registry alterados
         id: changed
         env:
-          BASE_REF: ${{ steps.pr.outputs.base }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
         run: |
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
-          FILES=$(git diff --name-only --diff-filter=ACMR "origin/$BASE_REF"...HEAD -- 'registry/plugins/**/*.json' || true)
+          # Lista os arquivos do PR pela API do GitHub — funciona igual em `pull_request`
+          # e em `/revalidate` (issue_comment). O git diff anterior falhava no caminho do
+          # comentário: o clone raso (--depth=1) + `gh pr checkout` deixavam o repo sem
+          # merge-base local, então `origin/main...HEAD` dava "no merge base", a lista
+          # ficava vazia e a validação era pulada silenciosamente.
+          FILES=$(gh pr view "$PR_NUMBER" --json files --jq '.files[].path' \
+            | grep -E '^registry/plugins/.*\.json$' || true)
           echo "Arquivos alterados:"
           echo "$FILES"
           {
@@ -116,3 +119,59 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
+
+      # ── Segurança: escaneia (Trivy) SÓ o(s) repo(s) submetido(s) neste PR e comenta os
+      # achados. Segredos vazados e vulnerabilidades CRITICAL reprovam o job (bloqueiam o
+      # merge); vulnerabilidades HIGH apenas sinalizam no comentário. Rodar aqui — e não no
+      # publish-catalog — garante que PRs abertos pelo bot (submit-plugin-issue) e
+      # revalidações via /revalidate também passem pela verificação.
+      - name: Instalar Trivy
+        if: steps.changed.outputs.files != ''
+        uses: aquasecurity/setup-trivy@v0.3.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Escanear segurança do repo submetido
+        id: security
+        if: steps.changed.outputs.files != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ONLY_FILES: ${{ steps.changed.outputs.files }}
+          SEVERITY: HIGH,CRITICAL
+          REPORT_FILE: ${{ runner.temp }}/pr-security.md
+          SECURITY_DIR: ${{ runner.temp }}/security
+        run: node scripts/security-scan.mjs
+
+      - name: Comentar segurança no PR
+        if: always() && steps.changed.outputs.files != ''
+        uses: actions/github-script@v9
+        env:
+          MD_PATH: ${{ runner.temp }}/pr-security.md
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        with:
+          script: |
+            const fs = require('fs');
+            const path = process.env.MD_PATH;
+            if (!fs.existsSync(path)) {
+              core.info('Sem markdown de segurança para comentar.');
+              return;
+            }
+            const marker = '<!-- registry-security -->';
+            const body = `${marker}\n\n${fs.readFileSync(path, 'utf8')}`;
+            const { owner, repo } = context.repo;
+            const issue_number = Number(process.env.PR_NUMBER);
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+      - name: Reprovar em segredos vazados ou vulnerabilidade CRITICAL
+        if: >-
+          (steps.security.outputs.secrets != '' && steps.security.outputs.secrets != '0') ||
+          (steps.security.outputs.critical != '' && steps.security.outputs.critical != '0')
+        run: |
+          echo "::error::Segredos vazados ou vulnerabilidade CRITICAL no(s) repo(s) submetido(s) — veja o comentário de segurança no PR."
+          exit 1

--- a/scripts/security-scan.mjs
+++ b/scripts/security-scan.mjs
@@ -29,11 +29,22 @@ const TOKEN = process.env.GITHUB_TOKEN || process.env.GH_TOKEN || '';
 // filename. build-catalog.mjs reads these to attach a `security` field to each
 // catalog entry. Defaults to <root>/dist/security.
 const SECURITY_DIR = process.env.SECURITY_DIR || fileURLToPath(new URL('../dist/security/', import.meta.url));
+// Optional allow-list of registry entries to scan, used by the PR check to scan ONLY the
+// files a Pull Request touched instead of the whole registry. Accepts full paths or bare
+// filenames, space/newline separated. Empty → scan everything (daily/full run).
+const ONLY_FILES = new Set(
+  (process.env.ONLY_FILES || '')
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => s.split('/').pop()),
+);
 
 function readRegistry() {
   const dir = new URL(REGISTRY_DIR);
   return readdirSync(dir)
     .filter((f) => f.endsWith('.json'))
+    .filter((f) => ONLY_FILES.size === 0 || ONLY_FILES.has(f))
     .map((f) => {
       const raw = readFileSync(new URL(f, REGISTRY_DIR), 'utf8');
       let repo = null;
@@ -265,8 +276,15 @@ function main() {
   console.log(`Per-repo security records written to ${SECURITY_DIR}`);
 
   if (process.env.GITHUB_OUTPUT) {
+    const secretsTotal = results.reduce((n, r) => n + (r.secrets?.length || 0), 0);
+    const criticalTotal = results.reduce(
+      (n, r) => n + (r.vulns?.filter((v) => v.severity === 'CRITICAL').length || 0),
+      0,
+    );
     appendFileSync(process.env.GITHUB_OUTPUT, `found=${hasFindings}\n`);
     appendFileSync(process.env.GITHUB_OUTPUT, `errors=${errored}\n`);
+    appendFileSync(process.env.GITHUB_OUTPUT, `secrets=${secretsTotal}\n`);
+    appendFileSync(process.env.GITHUB_OUTPUT, `critical=${criticalTotal}\n`);
   }
 
   // Never fail the job on findings — we surface them via summary + issue instead.


### PR DESCRIPTION
## Problemas

**1. `/revalidate` não fazia nada.** O comentário *disparava* o workflow e o job rodava, mas o passo de detectar arquivos usava um git diff sobre clone raso (`origin/main...HEAD` após `--depth=1` + `gh pr checkout`) que falhava com `fatal: origin/main...HEAD: no merge base` (confirmado no log do run 29998925622). Resultado: lista de arquivos vazia → "Validar registry" pulado → nenhum comentário. Parecia morto. Só quebrava no caminho `issue_comment`; em `pull_request` o `checkout@v7` já traz o histórico completo.

**2. Segurança não rodava de forma útil nos PRs.** O Trivy só rodava no cron diário/push, escaneando *todos* os repos e comentando numa *issue* rolante. O dry-run em PR do `publish-catalog` nunca comentava no PR e nem rodava pra PR aberto por bot.

## Mudanças

`.github/workflows/validate-registry-pr.yml`
- Detecção de arquivos agora usa `gh pr view N --json files` (API) — funciona igual em `pull_request` e `/revalidate`, sem depender de merge-base local. **Conserta o `/revalidate`.**
- Novos steps: instala Trivy → escaneia **só o(s) repo(s) submetido(s)** (`ONLY_FILES`) → comenta no PR com marcador `<!-- registry-security -->` (separado da validação de registry).

`scripts/security-scan.mjs`
- Suporte a `ONLY_FILES` (escaneia só os arquivos do PR, não o registry inteiro).
- Novos outputs `secrets` e `critical` pro workflow decidir se bloqueia.

## Regra de bloqueio no PR

| Achado | Comportamento |
|---|---|
| Secret vazado | ❌ Reprova (trava merge) |
| Vuln CRITICAL | ❌ Reprova (trava merge) |
| Vuln HIGH | ⚠️ Só comenta |
| Scan error | ⚠️ Só comenta |

## Notas
- `node --check` OK; filtro `ONLY_FILES` testado localmente (dos 25 do registry, seleciona só o arquivo do PR).
- O efeito no `/revalidate` só vale **depois do merge no `main`** — eventos `issue_comment` sempre usam o workflow da branch default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)