### PR TITLE
Add Google Analytics 4 to the marketing site

### DIFF
--- a/apps/marketing-site/assets/analytics.js
+++ b/apps/marketing-site/assets/analytics.js
@@ -1,0 +1,103 @@
+/* global window, document */
+//
+// Google Analytics 4 for the marketing site.
+//
+// Single place that knows the measurement ID and every custom event, so the three
+// pages (/, /plugins/, /updates/) only have to include this one script. Events are
+// wired through delegated document listeners, which means they keep working for
+// markup rendered later by catalog.js / updates.js.
+//
+// GA4's Enhanced Measurement already covers page_view, scroll, outbound clicks and
+// file downloads. What it can't see is intent that never leaves the page — opening
+// the download modal, copying the install one-liner, opening a plugin sheet — so
+// those are the ones tracked explicitly below.
+(function () {
+  'use strict';
+
+  // GA4 measurement ID for the ulanzicommunitystore.narlei.com property.
+  var MEASUREMENT_ID = 'G-S29VT6PEEX';
+
+  // A real ID can legitimately contain an X, so only the exact placeholder counts.
+  function isPlaceholder(id) {
+    return !id || id === 'G-XXXXXXXXXX';
+  }
+
+  // Local previews and file:// would otherwise pollute the property with fake traffic.
+  function isLocal() {
+    var host = window.location.hostname;
+    return (
+      window.location.protocol === 'file:' ||
+      host === 'localhost' ||
+      host === '127.0.0.1' ||
+      host === '::1' ||
+      host.indexOf('.local') !== -1
+    );
+  }
+
+  var enabled = !isPlaceholder(MEASUREMENT_ID) && !isLocal();
+
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    window.dataLayer.push(arguments);
+  }
+  // The standard GA snippet exposes this globally; keep that contract for anything
+  // that expects to call gtag() directly.
+  window.gtag = window.gtag || gtag;
+
+  // Safe to call from anywhere — a no-op until a real ID is configured.
+  window.trackEvent = function (name, params) {
+    if (!enabled) return;
+    gtag('event', name, params || {});
+  };
+
+  if (enabled) {
+    var tag = document.createElement('script');
+    tag.async = true;
+    tag.src = 'https://www.googletagmanager.com/gtag/js?id=' + MEASUREMENT_ID;
+    document.head.appendChild(tag);
+
+    gtag('js', new Date());
+    gtag('config', MEASUREMENT_ID);
+  }
+
+  // ---- Custom events ----
+
+  // Which of the download buttons was clicked (nav, hero, bottom CTA).
+  function placementOf(el) {
+    return el.getAttribute('data-analytics-placement') || 'unknown';
+  }
+
+  // The download modal shows one panel per OS; the visible one is the user's pick.
+  function activeOs() {
+    var btn = document.querySelector('#downloadModal .modal-os-btn.is-active');
+    return (btn && btn.getAttribute('data-os')) || 'unknown';
+  }
+
+  document.addEventListener('click', function (event) {
+    var target = event.target;
+    if (!target || typeof target.closest !== 'function') return;
+
+    // Opens the download modal on / and /plugins/; on /updates/ there is no modal
+    // and the link goes straight to the releases page.
+    var trigger = target.closest('.js-download-trigger');
+    if (trigger) {
+      window.trackEvent('download_click', { placement: placementOf(trigger) });
+      return;
+    }
+
+    var direct = target.closest('.modal-direct a[href]');
+    if (direct) {
+      var href = direct.getAttribute('href') || '';
+      var isInstaller = /\.(dmg|exe)$/i.test(href);
+      window.trackEvent(isInstaller ? 'installer_download' : 'releases_page_open', {
+        os: isInstaller ? (/\.dmg$/i.test(href) ? 'macos' : 'windows') : activeOs(),
+      });
+      return;
+    }
+
+    var copy = target.closest('#downloadModal .modal-copy');
+    if (copy) {
+      window.trackEvent('install_command_copy', { os: activeOs() });
+    }
+  });
+})();

--- a/apps/marketing-site/assets/catalog.js
+++ b/apps/marketing-site/assets/catalog.js
@@ -547,7 +547,7 @@
       escapeHtml(plugin.author || '') +
       '</p>' +
       '</div>' +
-      '<button type="button" class="button button-sm catalog-get js-download-trigger" data-stop>' +
+      '<button type="button" class="button button-sm catalog-get js-download-trigger" data-analytics-placement="catalog_card" data-stop>' +
       escapeHtml(t('catalog_get_app')) +
       '</button>' +
       '</div>' +
@@ -731,6 +731,11 @@
     document.body.style.overflow = 'hidden';
     var closeBtn = document.getElementById('pluginDetailClose');
     if (closeBtn) closeBtn.focus();
+
+    // No-op unless analytics.js is loaded with a real measurement ID.
+    if (typeof window.trackEvent === 'function') {
+      window.trackEvent('view_plugin', { plugin_repo: plugin.repo, plugin_name: name });
+    }
 
     // Reflect the open plugin in the URL so it can be shared / deep-linked.
     // Skipped when opening from an existing history entry (initial load, Back/Forward).

--- a/apps/marketing-site/index.html
+++ b/apps/marketing-site/index.html
@@ -29,6 +29,7 @@
 
     <link rel="stylesheet" href="/assets/style.css?v=20260724a">
     <script src="/assets/i18n.js?v=20260724a"></script>
+    <script src="/assets/analytics.js?v=20260725a" defer></script>
     <script src="/assets/release-downloads.js?v=20260714b" defer></script>
   </head>
   <body id="top">
@@ -56,7 +57,7 @@
             <button type="button" class="lang-btn" data-set-lang="pt" aria-pressed="false">PT</button>
             <button type="button" class="lang-btn" data-set-lang="zh" aria-pressed="false">中文</button>
           </div>
-          <a class="button button-sm js-download-trigger" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
+          <a class="button button-sm js-download-trigger" data-analytics-placement="nav" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
             <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 1a.75.75 0 0 1 .75.75v7.19l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0L3.72 7.53a.75.75 0 0 1 1.06-1.06l2.47 2.47V1.75A.75.75 0 0 1 8 1ZM2 12.25a.75.75 0 0 1 1.5 0v1.25h9v-1.25a.75.75 0 0 1 1.5 0v1.5c0 .69-.56 1.25-1.25 1.25H3.25C2.56 15 2 14.44 2 13.75v-1.5Z"/></svg>
             <span data-i18n="nav_download">Download</span>
           </a>
@@ -81,7 +82,7 @@
             with a single Pull Request.
           </p>
           <div class="actions">
-            <a class="button button-lg js-download-trigger" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
+            <a class="button button-lg js-download-trigger" data-analytics-placement="hero" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
               <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 1a.75.75 0 0 1 .75.75v7.19l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0L3.72 7.53a.75.75 0 0 1 1.06-1.06l2.47 2.47V1.75A.75.75 0 0 1 8 1ZM2 12.25a.75.75 0 0 1 1.5 0v1.25h9v-1.25a.75.75 0 0 1 1.5 0v1.5c0 .69-.56 1.25-1.25 1.25H3.25C2.56 15 2 14.44 2 13.75v-1.5Z"/></svg>
               <span data-i18n="hero_download">Download for free</span>
             </a>
@@ -536,7 +537,7 @@
           <img class="cta-icon" src="assets/logo-512.png" alt="" width="72" height="72">
           <h2 data-i18n="cta_title">All community plugins in a single app.</h2>
           <p data-i18n="cta_sub">Free, open source, and ready in seconds.</p>
-          <a class="button button-lg js-download-trigger" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
+          <a class="button button-lg js-download-trigger" data-analytics-placement="cta" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
             <svg viewBox="0 0 16 16" width="18" height="18" fill="currentColor" aria-hidden="true"><path d="M8 1a.75.75 0 0 1 .75.75v7.19l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0L3.72 7.53a.75.75 0 0 1 1.06-1.06l2.47 2.47V1.75A.75.75 0 0 1 8 1ZM2 12.25a.75.75 0 0 1 1.5 0v1.25h9v-1.25a.75.75 0 0 1 1.5 0v1.5c0 .69-.56 1.25-1.25 1.25H3.25C2.56 15 2 14.44 2 13.75v-1.5Z"/></svg>
             <span data-i18n="cta_download">Download the latest release</span>
           </a>

--- a/apps/marketing-site/plugins/index.html
+++ b/apps/marketing-site/plugins/index.html
@@ -28,8 +28,9 @@
 
     <link rel="stylesheet" href="/assets/style.css?v=20260724a">
     <script src="/assets/i18n.js?v=20260724a"></script>
+    <script src="/assets/analytics.js?v=20260725a" defer></script>
     <script src="/assets/release-downloads.js?v=20260714b" defer></script>
-    <script src="/assets/catalog.js?v=20260714a" defer></script>
+    <script src="/assets/catalog.js?v=20260725a" defer></script>
   </head>
   <body id="top" class="page-catalog">
     <div class="bg" aria-hidden="true">
@@ -56,7 +57,7 @@
             <button type="button" class="lang-btn" data-set-lang="pt" aria-pressed="false">PT</button>
             <button type="button" class="lang-btn" data-set-lang="zh" aria-pressed="false">中文</button>
           </div>
-          <a class="button button-sm js-download-trigger" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
+          <a class="button button-sm js-download-trigger" data-analytics-placement="nav" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
             <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 1a.75.75 0 0 1 .75.75v7.19l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0L3.72 7.53a.75.75 0 0 1 1.06-1.06l2.47 2.47V1.75A.75.75 0 0 1 8 1ZM2 12.25a.75.75 0 0 1 1.5 0v1.25h9v-1.25a.75.75 0 0 1 1.5 0v1.5c0 .69-.56 1.25-1.25 1.25H3.25C2.56 15 2 14.44 2 13.75v-1.5Z"/></svg>
             <span data-i18n="nav_download">Download</span>
           </a>
@@ -77,7 +78,7 @@
             <strong data-i18n="catalog_banner_title">Install happens in the app</strong>
             <p data-i18n="catalog_banner_body">Browsing here is free. To install a plugin on your Ulanzi Deck or Dial, download the Community Store app.</p>
           </div>
-          <a class="button button-sm js-download-trigger" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer" data-i18n="catalog_get_app">Download the app</a>
+          <a class="button button-sm js-download-trigger" data-analytics-placement="catalog_banner" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer" data-i18n="catalog_get_app">Download the app</a>
         </div>
 
         <div class="catalog-toolbar">

--- a/apps/marketing-site/updates/index.html
+++ b/apps/marketing-site/updates/index.html
@@ -30,6 +30,7 @@
 
     <link rel="stylesheet" href="/assets/style.css?v=20260724a">
     <script src="/assets/i18n.js?v=20260724a"></script>
+    <script src="/assets/analytics.js?v=20260725a" defer></script>
     <script src="/assets/updates.js?v=20260724a" defer></script>
   </head>
   <body id="top" class="page-updates">
@@ -57,7 +58,7 @@
             <button type="button" class="lang-btn" data-set-lang="pt" aria-pressed="false">PT</button>
             <button type="button" class="lang-btn" data-set-lang="zh" aria-pressed="false">中文</button>
           </div>
-          <a class="button button-sm js-download-trigger" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
+          <a class="button button-sm js-download-trigger" data-analytics-placement="nav" href="https://github.com/narlei/ulanzicommunitystore/releases/latest" target="_blank" rel="noopener noreferrer">
             <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor" aria-hidden="true"><path d="M8 1a.75.75 0 0 1 .75.75v7.19l2.47-2.47a.75.75 0 1 1 1.06 1.06l-3.75 3.75a.75.75 0 0 1-1.06 0L3.72 7.53a.75.75 0 0 1 1.06-1.06l2.47 2.47V1.75A.75.75 0 0 1 8 1ZM2 12.25a.75.75 0 0 1 1.5 0v1.25h9v-1.25a.75.75 0 0 1 1.5 0v1.5c0 .69-.56 1.25-1.25 1.25H3.25C2.56 15 2 14.44 2 13.75v-1.5Z"/></svg>
             <span data-i18n="nav_download">Download</span>
           </a>


### PR DESCRIPTION
Adds GA4 to the marketing site (measurement ID `G-S29VT6PEEX`).

## How it's wired

New `assets/analytics.js` is the single place that knows the measurement ID and every custom event, included from all three pages. `/plugins/` and `/updates/` serve `index.html` through their PHP shims, so they pick it up with no extra work.

Events use delegated listeners on `document`, so they keep working for markup `catalog.js` renders after load (catalog cards, detail sheets).

## Events

Enhanced Measurement already covers `page_view`, scroll, outbound clicks and file downloads. These fill the gap it can't see — intent that never leaves the page:

| Event | Params | Fires on |
|---|---|---|
| `download_click` | `placement`: nav, hero, cta, catalog_banner, catalog_card | any download button |
| `installer_download` | `os`: macos/windows | direct `.dmg` / `.exe` link |
| `install_command_copy` | `os` | copying the curl/irm one-liner |
| `releases_page_open` | `os` | "All releases →" |
| `view_plugin` | `plugin_repo`, `plugin_name` | opening a plugin detail sheet |

## Guards

Nothing loads on `localhost` / `file://`, so local previews don't pollute the property, and nothing loads at all while the ID is the placeholder. `window.trackEvent()` is a safe no-op in both cases, which is why the `catalog.js` call site needs no branching.

## Verified

Served the site locally and drove all three pages: every event fires with the expected params (`view_plugin` returned `narlei/ulanzideck_battery_status`), no `.js-download-trigger` left without a placement, no console errors, and the localhost guard keeps `gtag.js` unloaded with an empty `dataLayer`. With a throwaway ID substituted, confirmed `gtag.js` loads and `dataLayer` receives `js` / `config` / `event` — then reverted.

## Follow-up after merge

`placement`, `os`, `plugin_repo` and `plugin_name` need registering under Admin → Custom definitions (Event scope) before they show up in reports. The events themselves count either way.

The site has no cookie banner, so there's no Consent Mode wiring here. Worth revisiting if EU traffic grows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)