### PR TITLE
Scope PR jobs to the entries the PR actually touches

### DIFF
--- a/.github/workflows/publish-catalog.yml
+++ b/.github/workflows/publish-catalog.yml
@@ -5,9 +5,16 @@ name: publish-catalog
 # every plugin repo so each catalog entry carries a `security` field, and posts findings
 # to a single rolling GitHub issue (opened on findings, closed when everything is clean).
 #
-# Pull requests that touch this pipeline run the same scan + build as a dry-run —
-# proving the pipeline works before merge — but skip the Pages deploy and leave the
-# rolling issue untouched.
+# This whole-registry pipeline deliberately does NOT run on pull requests: it clones and
+# scans ~30 third-party repos and rebuilds every catalog entry, none of which a submission
+# PR changes. What a PR needs — the scan and the build of the entries it actually touched —
+# runs in validate-registry-pr.yml instead.
+#
+# A maintainer who does want the full pipeline exercised against a PR (typically when the
+# PR changes the pipeline itself) can start it by hand: Actions → publish-catalog → Run
+# workflow, with `pr` set to the PR number. That builds and scans everything with the PR's
+# registry data overlaid, uploads the result as an artifact, and skips both the Pages
+# deploy and the rolling security issue.
 
 on:
   push:
@@ -17,15 +24,14 @@ on:
       - 'packages/catalog/**'
       - 'scripts/security-scan.mjs'
       - '.github/workflows/publish-catalog.yml'
-  pull_request:
-    paths:
-      - 'registry/**'
-      - 'packages/catalog/**'
-      - 'scripts/security-scan.mjs'
-      - '.github/workflows/publish-catalog.yml'
   schedule:
     - cron: '0 6 * * *' # every day at 06:00 UTC
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number to dry-run against (blank = normal build of the selected branch)'
+        required: false
+        default: ''
   repository_dispatch:
     types: [rebuild-catalog]
 
@@ -35,15 +41,19 @@ permissions:
   pages: write
   id-token: write
 
-# PR dry-runs get their own group so they never queue behind (or block) a real deploy;
-# a new push to the same PR cancels the previous dry-run.
+# Dry-runs get their own group so they never queue behind (or block) a real deploy;
+# re-running the dry-run for the same PR cancels the previous one.
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('catalog-pr-{0}', github.event.pull_request.number) || 'pages' }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ inputs.pr != '' && format('catalog-pr-{0}', inputs.pr) || 'pages' }}
+  cancel-in-progress: ${{ inputs.pr != '' }}
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      # `inputs` is empty for push/schedule/repository_dispatch, so this is only ever '1'
+      # on a hand-started run that named a PR.
+      DRY_RUN: ${{ inputs.pr != '' && '1' || '0' }}
     steps:
       # Full history: the catalog derives each plugin's `addedAt` (when it entered the
       # store) from the commit that added its registry/plugins/*.json. A shallow clone
@@ -51,6 +61,16 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Bring in the PR registry data
+        if: env.DRY_RUN == '1'
+        env:
+          PR_NUMBER: ${{ inputs.pr }}
+        run: |
+          # Same rule as validate-registry-pr: run the scripts from the ref this workflow was
+          # started on (trusted) and overlay ONLY the PR's registry data, never the PR's code.
+          git fetch --no-tags origin "pull/${PR_NUMBER}/head"
+          git checkout FETCH_HEAD -- registry/plugins/
 
       - uses: actions/setup-node@v7
         with:
@@ -82,9 +102,9 @@ jobs:
         run: cat security-report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Open / update / close security issue
-        # Dry-runs on PRs must not touch the rolling issue (and the PR token from a
-        # fork would be read-only anyway).
-        if: always() && github.event_name != 'pull_request'
+        # A dry-run reports on the PR's registry data, not on what is published — it must
+        # not touch the rolling issue.
+        if: always() && env.DRY_RUN != '1'
         uses: actions/github-script@v9
         with:
           script: |
@@ -134,22 +154,22 @@ jobs:
               });
             }
 
-      - if: github.event_name != 'pull_request'
+      - if: env.DRY_RUN != '1'
         uses: actions/upload-pages-artifact@v5
         with:
           path: dist/catalog
 
-      # On PRs, expose the built catalog + security report as a plain artifact
+      # On a dry-run, expose the built catalog + security report as a plain artifact
       # so reviewers can inspect exactly what would have been published.
-      - if: github.event_name == 'pull_request'
+      - if: env.DRY_RUN == '1'
         uses: actions/upload-artifact@v7
         with:
-          name: catalog-dry-run
+          name: catalog-dry-run-pr-${{ inputs.pr }}
           path: dist/catalog
           retention-days: 7
 
   deploy:
-    if: github.event_name != 'pull_request'
+    if: inputs.pr == ''
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/validate-registry-pr.yml
+++ b/.github/workflows/validate-registry-pr.yml
@@ -6,6 +6,11 @@ name: validate-registry-pr
 #
 # Besides the normal PR trigger, it accepts `/revalidate` in a maintainer comment — needed
 # because a PR opened by the bot (submit-plugin-issue) does not trigger workflows.
+#
+# Everything here is scoped to the entries the PR touched: the standards check, the Trivy
+# scan and the catalog build all run over those files only. The whole-registry pipeline
+# (publish-catalog.yml) stays off pull requests — see its header for the manual dry-run.
+# A PR that touches no registry entry therefore does no plugin work at all.
 
 on:
   pull_request:
@@ -53,6 +58,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '22'
+          cache: npm
 
       - name: Resolve the target PR
         id: pr
@@ -176,6 +182,46 @@ jobs:
             } else {
               await github.rest.issues.createComment({ owner, repo, issue_number, body });
             }
+
+      # ── Catalog: build ONLY the entries this PR touched, so the PR proves its own entry
+      # lands in the catalog (release asset, manifest, store.json, icon, banner) without
+      # rebuilding the other ~30. `--ignore-scripts` skips the Electron download, which the
+      # catalog build has no use for.
+      - name: Install dependencies
+        if: steps.changed.outputs.files != ''
+        run: npm ci --ignore-scripts
+
+      - name: Build the catalog entries from this PR
+        if: steps.changed.outputs.files != ''
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ONLY_FILES: ${{ steps.changed.outputs.files }}
+          # Reuses the records the scan above just wrote, so the built entries carry the
+          # same `security` field they would get in a real publish.
+          SECURITY_DIR: ${{ runner.temp }}/security
+          CATALOG_OUT_FILE: ${{ runner.temp }}/catalog-pr/catalog.json
+          # A partial catalog is never published, so an entry that fails to build is a
+          # problem with the PR, not something to warn about and move on from.
+          CATALOG_STRICT: '1'
+        run: |
+          {
+            echo '### Catalog build (entries in this PR)'
+            echo
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          node packages/catalog/bin/build-catalog.mjs 2>&1 | tee -a "$GITHUB_STEP_SUMMARY"
+          status=${PIPESTATUS[0]}
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          exit "$status"
+
+      - name: Upload the built entries
+        if: always() && steps.changed.outputs.files != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: catalog-pr-${{ steps.pr.outputs.number }}
+          path: ${{ runner.temp }}/catalog-pr
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Fail on leaked secrets or CRITICAL vulnerability
         if: >-

--- a/packages/catalog/bin/build-catalog.mjs
+++ b/packages/catalog/bin/build-catalog.mjs
@@ -6,6 +6,8 @@
 //
 // Usage:  GH_TOKEN=$(gh auth token) npm run catalog:build
 // In the Action, GITHUB_TOKEN is injected automatically.
+// Set ONLY_FILES to build a subset (see below) — that is how the PR check builds just the
+// entries a Pull Request touched.
 
 import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
@@ -19,6 +21,22 @@ import { renderBanner, renderDigestBanner } from './og-banner.mjs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..', '..', '..');
 const REGISTRY_DIR = join(ROOT, 'registry', 'plugins');
+// Optional allow-list of registry entries to build, same convention as
+// scripts/security-scan.mjs: the PR check passes the files the Pull Request touched so the
+// dry-run builds ONLY those entries instead of hitting the GitHub API for the whole
+// registry. Accepts full paths or bare filenames, space/newline separated.
+// Empty → build everything (the real publish, the daily run, a local build).
+const ONLY_FILES = new Set(
+  (process.env.ONLY_FILES || '')
+    .split(/\s+/)
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => s.split('/').pop()),
+);
+// A partial build is never publishable — it drops every entry the allow-list left out.
+// Used below to skip the whole-registry work (digest cards, completeness warnings) that
+// only makes sense for a full build.
+const PARTIAL = ONLY_FILES.size > 0;
 const OUT_FILE = process.env.CATALOG_OUT_FILE || join(ROOT, 'dist', 'catalog', 'catalog.json');
 // Social-share banners (og/<slug>.png) are written next to catalog.json and published to
 // Pages, so plugins/index.php can point og:image at them when a plugin link is shared.
@@ -725,6 +743,15 @@ async function main() {
     process.exit(1);
   }
 
+  if (PARTIAL) {
+    const known = new Set(files);
+    for (const wanted of ONLY_FILES) {
+      if (!known.has(wanted)) console.warn(`! ONLY_FILES lists ${wanted}, which is not in the registry`);
+    }
+    files = files.filter((f) => ONLY_FILES.has(f));
+    console.log(`Partial build: ${files.length} of ${known.size} registry entr(ies) — NOT publishable.`);
+  }
+
   const security = await loadSecurity();
   const addedAt = await buildAddedAtMap();
 
@@ -759,7 +786,10 @@ async function main() {
     generatedAt: new Date().toISOString(),
     count: plugins.length,
     plugins,
-    updates: { banners: await generateDigestBanners(plugins) },
+    // The digest cards summarise a time window across the WHOLE registry, so a partial
+    // build has nothing meaningful to render — and rendering ~28 cards would dominate the
+    // dry-run's runtime for output nobody publishes.
+    updates: { banners: PARTIAL ? {} : await generateDigestBanners(plugins) },
   };
 
   const outDir = dirname(OUT_FILE);
@@ -769,8 +799,12 @@ async function main() {
 
   // A shallow checkout resolves nothing here, which silently turns every plugin into an
   // "update" on the /updates page. Loud warning rather than a quietly wrong digest.
+  // Skipped on a partial build: the PR check overlays the entry's file without committing
+  // it, so `addedAt` is legitimately null and the warning would fire on every PR.
   const withAddedAt = plugins.filter((p) => p.addedAt).length;
-  if (plugins.length && !withAddedAt) {
+  if (PARTIAL) {
+    /* no addedAt expectation on a partial build */
+  } else if (plugins.length && !withAddedAt) {
     console.warn('! addedAt is null for every plugin — is this a shallow clone? (need fetch-depth: 0)');
   } else if (withAddedAt < plugins.length) {
     console.warn(`! addedAt missing for ${plugins.length - withAddedAt} plugin(s); they will read as updates`);


### PR DESCRIPTION
## Problem

A submission PR adds **one** entry to `registry/plugins/`, but `publish-catalog` ran its whole pipeline as a PR dry-run: cloning and Trivy-scanning ~30 third-party repos and rebuilding every catalog entry — none of which the PR changed. That is minutes of CI on every contribution, for an artifact nobody reads.

For reference, on #61 (a single new entry) the `publish-catalog` `build` job took 1m47s against 18s for `validate`.

## What changes

**`build-catalog.mjs` accepts `ONLY_FILES`** — same convention as `scripts/security-scan.mjs`: a list of files (full path or bare name), space/newline separated. Empty still builds everything (real publish, daily cron, local build). A partial build also skips the ~28 digest cards (they only mean anything over the whole registry, and would dominate the job's runtime) and the null-`addedAt` warning (the PR check overlays the file without committing it, so it is null by construction).

**`publish-catalog` drops its `pull_request` trigger.** Its `workflow_dispatch` gains a `pr` input, so a maintainer can still exercise the full pipeline against a PR by hand (Actions → publish-catalog → Run workflow) — useful when the PR changes the pipeline itself. That mode overlays only the PR's registry data (the scripts still come from the trusted ref, same rule as `validate-registry-pr`) and skips both the Pages deploy and the rolling security issue, uploading the result as an artifact.

**`validate-registry-pr` builds the PR's entries** — after the scan, which was already scoped. It uses `npm ci --ignore-scripts` (no need for the Electron download) and reuses the `SECURITY_DIR` the scan just wrote, so the entries carry the same `security` field a real publish would give them. `CATALOG_STRICT=1` makes an entry that cannot be built fail the PR. The log goes to the step summary and the partial catalog is uploaded as an artifact.

Every plugin step in `validate-registry-pr` is already guarded on `steps.changed.outputs.files != ''`, so **a PR that touches no registry entry now does no plugin work at all** — no scan, no build, no install.

## Verification

- Local partial build with two entries: `Partial build: 2 of 31 registry entr(ies)`, catalog with both plugins, zero digest banners.
- `ONLY_FILES` naming a file that is not in the registry warns instead of failing silently.
- `npm run catalog:validate` passes; both YAML files parse.
- This PR itself touches no registry entry: only `build` (ci, 28s) and `validate` (7s) ran — `publish-catalog` did not trigger at all.

## Note

There is no way to put a "play" button inside the PR checks — GitHub does not offer that for a skipped job. `workflow_dispatch` with the PR number is the closest thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
